### PR TITLE
wait for load event (fonts loaded)

### DIFF
--- a/js/fittext.js
+++ b/js/fittext.js
@@ -32,6 +32,7 @@ function fitAll(els) {
       el.innerText,
       getComputedStyle(el)
     );
+
     const widthRatio = containerWidth / textDimensions.width;
     const currentFontSize = parseFloat(getComputedStyle(el).fontSize);
     const maxFontSize = parseFloat(
@@ -50,6 +51,6 @@ function fitAll(els) {
   for (const el of els) fit(el);
 }
 
-window.addEventListener("DOMContentLoaded", () => {
+window.addEventListener("load", () => {
   fitAll(document.querySelectorAll(".fittext"));
 });


### PR DESCRIPTION
The fittext script ran on DOMContentLoaded which waits for the html to load, but not for stylesheets, images, and fonts.

The load event waits for the fully loaded page.

More info here: https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event