### PR TITLE
Allow fittext to grow to set font size

### DIFF
--- a/js/fittext.js
+++ b/js/fittext.js
@@ -28,9 +28,8 @@ function transformText(text, styles) {
 // Helper function to measure text with given styles
 function measureText(context, text, styles) {
   context.font = styles.font;
-  if (styles.letterSpacing !== "normal") {
-    context.letterSpacing = styles.letterSpacing;
-  }
+  if (styles.letterSpacing === "normal") context.letterSpacing = "0px";
+  else context.letterSpacing = styles.letterSpacing;
 
   const metrics = context.measureText(text);
 

--- a/js/fittext.js
+++ b/js/fittext.js
@@ -5,12 +5,18 @@
 
 function parseFontSize(fontSize) {
   if (typeof fontSize === "number") return fontSize;
-  if (fontSize.includes("rem")) {
+
+  if (fontSize.includes("var(")) {
+    const varName = fontSize.match(/var\((.*)\)/)[1];
+    fontSize = getComputedStyle(document.body).getPropertyValue(varName);
+  }
+
+  if (fontSize.includes("rem"))
     return (
       parseFloat(fontSize) *
       parseFloat(getComputedStyle(document.body).fontSize)
     );
-  }
+
   return parseFloat(fontSize);
 }
 

--- a/js/fittext.js
+++ b/js/fittext.js
@@ -3,12 +3,23 @@
  * To use it, add the class "fittext" to the element you want to fit.
  */
 
+function parseFontSize(fontSize) {
+  if (typeof fontSize === "number") return fontSize;
+  if (fontSize.includes("rem")) {
+    return (
+      parseFloat(fontSize) *
+      parseFloat(getComputedStyle(document.body).fontSize)
+    );
+  }
+  return parseFloat(fontSize);
+}
+
 // Helper function to transform text based on CSS text-transform
 function transformText(text, styles) {
   const transform = styles.textTransform;
-  if (transform === 'uppercase') return text.toUpperCase();
-  if (transform === 'lowercase') return text.toLowerCase();
-  if (transform === 'capitalize') {
+  if (transform === "uppercase") return text.toUpperCase();
+  if (transform === "lowercase") return text.toLowerCase();
+  if (transform === "capitalize") {
     return text.replace(/\b\w/g, (c) => c.toUpperCase());
   }
   return text;
@@ -17,7 +28,7 @@ function transformText(text, styles) {
 // Helper function to measure text with given styles
 function measureText(context, text, styles) {
   context.font = styles.font;
-  if (styles.letterSpacing !== 'normal') {
+  if (styles.letterSpacing !== "normal") {
     context.letterSpacing = styles.letterSpacing;
   }
 
@@ -25,8 +36,7 @@ function measureText(context, text, styles) {
 
   return {
     width: metrics.width,
-    height:
-      metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent,
+    height: metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent,
   };
 }
 
@@ -34,17 +44,17 @@ function getTextDimensions(element, styles) {
   // re-use canvas object for better performance
   const canvas =
     getTextDimensions.canvas ||
-    (getTextDimensions.canvas = document.createElement('canvas'));
+    (getTextDimensions.canvas = document.createElement("canvas"));
 
   // If canvas isn't on DOM yet, append it
   if (window.DEBUG_DRAW && !canvas.parentNode) {
     canvas.width = 1080;
     canvas.height = 500;
-    canvas.style.backgroundColor = 'aliceblue';
+    canvas.style.backgroundColor = "aliceblue";
     document.body.appendChild(canvas);
   }
 
-  const context = canvas.getContext('2d');
+  const context = canvas.getContext("2d");
 
   // Process all nodes and total their dimensions
   function processNode(node, parentStyles) {
@@ -70,19 +80,14 @@ function getTextDimensions(element, styles) {
 
           if (
             (child.nextSibling ||
-              (child.parentNode !== element &&
-                child.parentNode.nextSibling)) &&
+              (child.parentNode !== element && child.parentNode.nextSibling)) &&
             (child.nextSibling?.textContent.trim() ||
               child.parentNode.nextSibling?.textContent.trim())
           ) {
-            processedText += ' ';
+            processedText += " ";
           }
 
-          const dimensions = measureText(
-            context,
-            processedText,
-            nodeStyles
-          );
+          const dimensions = measureText(context, processedText, nodeStyles);
 
           // Draw the text on the canvas
           if (window.DEBUG_DRAW) {
@@ -130,19 +135,24 @@ function fitAll(els) {
     const textDimensions = getTextDimensions(el, getComputedStyle(el));
 
     const widthRatio = containerWidth / textDimensions.width;
-    const currentFontSize = parseFloat(getComputedStyle(el).fontSize);
-    const maxFontSize = parseFloat(
-      getComputedStyle(el).getPropertyValue('--max-font-size') ||
-        currentFontSize
+    const setFontSize = parseFontSize(
+      Array.from(document.styleSheets)
+        .filter((sheet) => !sheet.href) // Filter out remote stylesheets
+        .map((sheet) => Array.from(sheet.cssRules))
+        .flat()
+        .filter((rule) => el.matches(rule.selectorText)) // Find CSS Rules that apply to the current element
+        .map((rule) => rule.style.fontSize)
+        .filter((fs) => fs)[0]
     );
-    const minFontSize = parseFloat(
-      getComputedStyle(el).getPropertyValue('--min-font-size') || 0
+    const currentFontSize = parseFontSize(getComputedStyle(el).fontSize);
+    const maxFontSize = parseFontSize(
+      getComputedStyle(el).getPropertyValue("--max-font-size") || setFontSize
+    );
+    const minFontSize = parseFontSize(
+      getComputedStyle(el).getPropertyValue("--min-font-size") || 0
     );
     const newFontSize = Math.floor(
-      Math.max(
-        minFontSize,
-        Math.min(currentFontSize * widthRatio, maxFontSize)
-      )
+      Math.max(minFontSize, Math.min(currentFontSize * widthRatio, maxFontSize))
     );
     el.style.fontSize = `${newFontSize}px`;
   }
@@ -150,15 +160,13 @@ function fitAll(els) {
   for (const el of els) fit(el);
 }
 
-window.addEventListener('load', () => {
+window.addEventListener("load", () => {
   window.DEBUG_DRAW =
-    new URLSearchParams(window.location.search).get('debug_draw') ===
-    'true';
+    new URLSearchParams(window.location.search).get("debug_draw") === "true";
 
   for (window.i = 0; i < 3; i++) {
     window.currentWidth = 0;
-    fitAll(document.querySelectorAll('.fittext'));
+    fitAll(document.querySelectorAll(".fittext"));
   }
   window.FITTEXT_COMPLETED = true;
 });
-


### PR DESCRIPTION
This is mainly used in the editor, and it allows for fittext elements to grow when deleting characters.

## What we did before
- The max font size was set to the CSS variable `--max-font-size` or the current font size if that was not set
- This would result in the max font size being the font size already set by fittext if it already ran

### Example
1. User types -> fittext shrinks font size to 56px to fit width
2. User deleted characters -> max font size is 56px, and therefore does not grow

## What we do now
- The max font size is still set to the CSS variable `--max-font-size` if available, and if not it falls back to the font size set in the `<style>` tag
- This means the max font size will ignore the inline font size set by fittext