### PR TITLE
Add fittext groups

### DIFF
--- a/js/fittext.js
+++ b/js/fittext.js
@@ -162,7 +162,26 @@ function fitAll(els) {
     el.style.fontSize = `${newFontSize}px`;
   }
 
-  for (const el of els) fit(el);
+  let groups = [];
+
+  for (const el of els) {
+    fit(el);
+    const group = el.getAttribute("data-fittext-group");
+    if (group && !groups.includes(group)) groups.push(group);
+  }
+
+  // Group elements by data-fittext-group
+  for (const group of groups) {
+    const groupElements = document.querySelectorAll(
+      `[data-fittext-group="${group}"]`
+    );
+    const minFontSize = Math.min(
+      ...Array.from(groupElements).map((el) =>
+        parseFontSize(getComputedStyle(el).fontSize)
+      )
+    );
+    for (const el of groupElements) el.style.fontSize = `${minFontSize}px`;
+  }
 }
 
 window.addEventListener("load", () => {


### PR DESCRIPTION
Sometimes we want two (or more) different fittext elements to always have the same font size. This change allows that.

## How it works
1. We run the same font size process as normal, keeping a list of all the fittext groups defined (if any)
2. After, we go through every fittext group and set each element in that group's font size to the minimum of the group