### PR TITLE
bleed absolute should set the position back to absolute

### DIFF
--- a/bleed.css
+++ b/bleed.css
@@ -108,6 +108,8 @@
 
 /* If the element is absolutely positioned, we need to adjust the bleed */
 .bleed-absolute {
+  position: absolute;
+
   &::before {
     content: none;
   }


### PR DESCRIPTION
`bleed-absolute` is meant to be used on absolute-positioned elements, but we were still overriding the position to relative above on line 56